### PR TITLE
Improvements for `dshackle` chart

### DIFF
--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/templates/_helpers.tpl
+++ b/charts/dshackle/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+HTTP port
+*/}}
+{{- define "dshackle.httpPort" -}}
+{{- default 443 .Values.externalHttpPort }}
+{{- end }}

--- a/charts/dshackle/templates/ingress.yaml
+++ b/charts/dshackle/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dshackle.fullname" . -}}
-{{- $svcPort := .Values.httpPort -}}
+{{- $svcPort := .Values.externalHttpPort -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/dshackle/templates/service-headless.yaml
+++ b/charts/dshackle/templates/service-headless.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.httpPort }}
-      targetPort: http
+    - port: {{ .Values.externalHttpPort }}
+      targetPort: {{ .Values.internalHttpPort }}
       protocol: TCP
       name: http
     - port: {{ .Values.gRPCPort }}

--- a/charts/dshackle/templates/service.yaml
+++ b/charts/dshackle/templates/service.yaml
@@ -4,11 +4,13 @@ metadata:
   name: {{ include "dshackle.fullname" . }}
   labels:
     {{- include "dshackle.labels" . | nindent 4 }}
+  annotations:
+    {{ toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.httpPort }}
-      targetPort: http
+    - port: {{ .Values.externalHttpPort }}
+      targetPort: {{ .Values.internalHttpPort }}
       protocol: TCP
       name: http
     - port: {{ .Values.gRPCPort }}

--- a/charts/dshackle/templates/statefulset.yaml
+++ b/charts/dshackle/templates/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
               readOnly: true
           ports:
             - name: http
-              containerPort: {{ .Values.httpPort }}
+              containerPort: {{ .Values.internalHttpPort }}
               protocol: TCP
             - name: grpc
               containerPort: {{ .Values.gRPCPort }}

--- a/charts/dshackle/values.yaml
+++ b/charts/dshackle/values.yaml
@@ -109,9 +109,13 @@ annotations: {}
 # @default -- See `values.yaml`
 gRPCPort: 2449
 
-# -- HTTP Port
+# -- External HTTP Port, where the service is exposed
 # @default -- See `values.yaml`
-httpPort: 8545
+externalHttpPort: 443
+
+# -- Internal HTTP Port, where pod and application running in the container are listening
+# @default -- See `values.yaml`
+internalHttpPort: 8545
 
 # -- Metrics Port
 # @default -- See `values.yaml`

--- a/charts/dshackle/values.yaml
+++ b/charts/dshackle/values.yaml
@@ -33,7 +33,7 @@ config: |
 
   proxy:
     host: 0.0.0.0
-    port: {{ .Values.httpPort }}
+    port: {{ .Values.internalHttpPort }}
     routes:
       - id: eth
         blockchain: ethereum


### PR DESCRIPTION
- add definition missing for `dshackle.httpPort`
- adding `annotations` support for configuring a Service of type `LoadBalancer`
- adding support for setting up the external and internal listening ports - for SSL support on 443